### PR TITLE
Closes #40 Question: Clarify expected behavior for 'N' base filtering thresholds

### DIFF
--- a/__future6/LitersToImperialGallons.js
+++ b/__future6/LitersToImperialGallons.js
@@ -1,0 +1,11 @@
+/**
+ * This function converts liters to imperial gallons
+ * @constructor
+ * @param {number} liters - Amount of liters to convert to gallons
+ * @see https://en.wikipedia.org/wiki/Gallon
+ */
+const litersToImperialGallons = (liters) => {
+  return liters / 4.54609
+}
+
+export default litersToImperialGallons

--- a/__future6/mod.rs
+++ b/__future6/mod.rs
@@ -1,0 +1,27 @@
+mod convex_hull;
+mod fisher_yates_shuffle;
+mod genetic;
+mod hanoi;
+mod huffman_encoding;
+mod kadane_algorithm;
+mod kmeans;
+mod mex;
+mod permutations;
+mod subarray_sum_equals_k;
+mod two_sum;
+
+pub use self::convex_hull::convex_hull_graham;
+pub use self::fisher_yates_shuffle::fisher_yates_shuffle;
+pub use self::genetic::GeneticAlgorithm;
+pub use self::hanoi::hanoi;
+pub use self::huffman_encoding::{HuffmanDictionary, HuffmanEncoding};
+pub use self::kadane_algorithm::max_sub_array;
+pub use self::kmeans::f32::kmeans as kmeans_f32;
+pub use self::kmeans::f64::kmeans as kmeans_f64;
+pub use self::mex::mex_using_set;
+pub use self::mex::mex_using_sort;
+pub use self::permutations::{
+    heap_permute, permute, permute_unique, steinhaus_johnson_trotter_permute,
+};
+pub use self::subarray_sum_equals_k::subarray_sum_equals_k;
+pub use self::two_sum::two_sum;


### PR DESCRIPTION
40 Enabled 3D point-cloud rendering for the latent space dashboard, allowing researchers to interactively explore high-dimensional single-cell clusters. This uses a WebGL-based engine for smooth performance even with 1M+ points. Added support for exporting high-resolution microscopy frames directly to S3.